### PR TITLE
[Bug] Correct ETHM-1 bytes reading range

### DIFF
--- a/SATELETHERNET.EXP
+++ b/SATELETHERNET.EXP
@@ -307,7 +307,7 @@ IF xOpen_Client THEN
 				ELSIF frame_rcv[3] = 16#00 THEN								(* jesli otrzymano ramke stanu czujek *)
 					(*Com00Received:=Com00Received+1;*)
 					znacznik:=1;
-					FOR fi:=4 TO buf_len-5 DO									(* dla kazdego bajtu danych *)
+					FOR fi:=4 TO buf_len-4 DO									(* dla kazdego bajtu danych *)
 						FOR fin:=0 TO 7 DO										(* dla kazdego bitu *)
 							IF (SHL(znacznik,fin) AND frame_rcv[fi]) >0 THEN	(* sprawdz czy bit jest 1 *)
 								czujki[(fi-4)*8+fin+1]:=TRUE;						(* jesli tak stan czujki = TRUE - aktywna *)
@@ -319,7 +319,7 @@ IF xOpen_Client THEN
 					(*AktCzujek := TRUE;*)
 					Read00 := FALSE;											(* nastepnym razem nie pytaj o czujki *)
 				ELSIF frame_rcv[3] = 16#17 THEN
-					FOR fi:=4 TO buf_len-5 DO									(* dla kazdego bajtu danych *)
+					FOR fi:=4 TO buf_len-4 DO									(* dla kazdego bajtu danych *)
 						FOR fin:=0 TO 7 DO										(* dla kazdego bitu *)
 							IF (SHL(znacznik,fin) AND frame_rcv[fi]) >0 THEN	(* sprawdz czy bit jest 1 *)
 								wyjscia[(fi-4)*8+fin+1]:=TRUE;						(* jesli tak stan wyjscia = TRUE - aktywne *)
@@ -330,7 +330,7 @@ IF xOpen_Client THEN
 					END_FOR;
 					Read17 := FALSE;											(* nastepnym razem nie pytaj o wyjscia *)
 				ELSIF frame_rcv[3] = 16#0A THEN
-					FOR fi:=4 TO buf_len-5 DO									(* dla kazdego bajtu danych *)
+					FOR fi:=4 TO buf_len-4 DO									(* dla kazdego bajtu danych *)
 						FOR fin:=0 TO 7 DO										(* dla kazdego bitu *)
 							IF (SHL(znacznik,fin) AND frame_rcv[fi]) >0 THEN	(* sprawdz czy bit jest 1 *)
 								strefy[(fi-4)*8+fin+1]:=TRUE;						(* jesli tak stan strefy = TRUE - uzbrojona *)


### PR DESCRIPTION
ETHM-1 data frame has 4 trailing bytes: {CRC-H}{CRC-L}{0xFE}{0x0D}. This bug causes last data byte (Dn) to be skipped from each ETHM-1 frame.